### PR TITLE
fix: return more file properties for use in saving

### DIFF
--- a/playground/server/api/files.ts
+++ b/playground/server/api/files.ts
@@ -10,4 +10,7 @@ export default defineEventHandler(async (event) => {
 interface File {
 	name: string
 	content: string
+	size: string
+	type: string
+	lastModified: string
 }

--- a/src/runtime/composables/useFileStorage.ts
+++ b/src/runtime/composables/useFileStorage.ts
@@ -7,6 +7,10 @@ export default function () {
 		reader.onload = (e: any) => {
 			files.value.push({
 				...file,
+				name: file.name,
+				size: file.size,
+				type: file.type,
+				lastModified: file.lastModified,
 				content: e.target.result,
 			})
 		}
@@ -31,4 +35,5 @@ export default function () {
 interface File extends Blob {
 	content: any
 	name: string
+	lastModified: string
 }


### PR DESCRIPTION
This fixes issue #4 for me because of the extra properties that are now available in de backend.
