### PR TITLE
Support for saving 'FormData' data formats

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,12 +77,15 @@ You can use Nuxt Storage to get the files from the `<input>` tag:
 
 <script setup>
 	// handleFileInput can handle multiple files
-	const { handleFileInput, files } = useFileStorage()
+	const { handleFileInput, files, filesList } = useFileStorage()
 </script>
 ```
-The `files` return a ref object that contains the files
+The `files` return a ref object that contains the files, `files` is file Base64 text
+
+The `filesList` return a ref object that contains the files, `filesList` is file Object
 
 Here's an example of using files to send them to the backend:
+#### Method one, use `files`
 ```html
 <template>
 	<input type="file" @input="handleFileInput" />
@@ -128,6 +131,49 @@ interface File {
 	name: string
 	content: string
 }
+```
+
+And that's it! Now you can store any file in your nuxt project from the user ✨
+#### Method two, use `filesList`
+```html
+<template>
+	<input type="file" @input="handleFileInput" />
+	<button @click="submit">submit</button>
+</template>
+
+<script setup>
+const { handleFileInput, filesList } = useFileStorage()
+
+const submit = async () => {
+	const formData= new FormData()
+	Array.from(filesList.value).forEach((file)=>{
+		formData.append('file', file)
+	})
+	const response = await $fetch('/api/files', {
+		method: 'POST',
+		body: formData
+	})
+}
+</script>
+```
+
+
+### Handling files in the backend
+using Nitro Server Engine, we will make an api route that recieves the files and stores them in the folder `userFiles`
+```ts
+export default defineEventHandler(async (event) => {
+	const files = (await readMultipartFormData(event)) || []
+	const file0 = files.find(item => item.name === 'file' && item.type)
+	if(!file0) return 'no file'
+	await storeFileFormData(
+		file, // the stringified version of the file
+		8,            // you can add a name for the file or length of Unique ID that will be automatically generated!
+		'/userFiles'  // the folder the file will be stored in
+	)
+
+	return 'success!'
+})
+
 ```
 
 And that's it! Now you can store any file in your nuxt project from the user ✨

--- a/playground/app.vue
+++ b/playground/app.vue
@@ -36,17 +36,18 @@
 					/>
 				</label>
 				<button @click="submit">submit</button>
+				<button @click="submit2">submit type FormData</button>
 				<p>{{ approveUpload }}</p>
 			</div>
 			<div class="images">
 				<img v-for="file in files" :key="file.name" :src="file.content" alt="file.name" />
 			</div>
-	</div>
+		</div>
 	</div>
 </template>
 
 <script setup lang="ts">
-const { handleFileInput, files } = useFileStorage()
+const { handleFileInput, files,filesList } = useFileStorage()
 
 const fileInput = ref<HTMLInputElement>()
 
@@ -69,6 +70,22 @@ const submit = async () => {
 		body: {
 			files: files.value,
 		},
+	})
+	if (!response) return
+	approveUpload.value = 'Uploaded files successfully!'
+	fileLinks.value = response
+}
+
+// use send FormData
+const submit2=async()=>{
+	const formData= new FormData()
+	Array.from(filesList.value).forEach((file)=>{
+		formData.append('file', file)
+	})
+
+	const response = await $fetch('/api/files2', {
+		method: 'POST',
+		body: formData,
 	})
 	if (!response) return
 	approveUpload.value = 'Uploaded files successfully!'

--- a/playground/server/api/files2.ts
+++ b/playground/server/api/files2.ts
@@ -1,0 +1,12 @@
+export default defineEventHandler(async (event) => {
+
+	const files = (await readMultipartFormData(event)) || []
+
+	// const { files } = await readBody<{ files: File[] }>(event)
+	console.log('files :>> ', files);
+	const fileNames: string[] = []
+	for (const file of files) {
+		if (file.type) fileNames.push(await storeFileFormData(file, 12, '/specificFolder'))
+	}
+	return fileNames
+})

--- a/src/runtime/composables/useFileStorage.ts
+++ b/src/runtime/composables/useFileStorage.ts
@@ -2,6 +2,7 @@ import { ref } from "vue";
 
 export default function () {
 	const files = ref<File[]>([])
+	const filesList = ref<File[]>([])
 	const serializeFile = (file: File) => {
 		const reader = new FileReader()
 		reader.onload = (e: any) => {
@@ -15,15 +16,17 @@ export default function () {
 
 	const handleFileInput = (event: any) => {
 		files.value.splice(0)
-		console.log('handleFileInput event: ' + event)
+		console.log('handleFileInput event: ', event)
 
 		for (const file of event.target.files) {
+			filesList.value.push(file)
 			serializeFile(file)
 		}
 	}
 
 	return {
 		files,
+		filesList,
 		handleFileInput,
 	}
 }

--- a/src/runtime/server/utils/storage.ts
+++ b/src/runtime/server/utils/storage.ts
@@ -1,5 +1,7 @@
 import { writeFile, rm, mkdir } from 'fs/promises'
+import { MultiPartData } from 'h3'
 import { useRuntimeConfig } from '#imports'
+import { extname } from 'path'
 
 /**
  * @returns mime type
@@ -58,4 +60,63 @@ export const parseDataUrl = (file: string) => {
 	const ext = mime.split('/')[1]
 
 	return { binaryString, ext }
+}
+
+
+/**
+ *	URL address splicing
+ * @param arg string
+ * @returns string
+ * @example
+ * pathJoin('upload','image','/2024/5','demo.png')	// upload/image/2024/5/demo.png
+ */
+export const pathJoin = (...arg: string[]) => {
+	const arr: string[] = []
+	arg.forEach((item) => {
+		item = item?.toString()?.trim()
+		if (!item) return
+		// Remove the leading slash,The first value of `arr` is not processed.
+		if (item.startsWith('/') && arr.length > 0) item = item.slice(1)
+		// Remove the trailing slash
+		if (item.endsWith('/')) item = item.slice(0, -1)
+		arr.push(item)
+	})
+	return arr.join('/')
+}
+
+
+/**
+ * Save the 'FormData' data type method
+ * @param fileData file data
+ * @param fileNameOrIdLength fileNameOrIdLength: you can pass a string or a number, if you enter a string it will be the file name, if you enter a number it will generate a unique ID
+ * @param filelocation filelocation: the directory where you want to store the file, you can pass an empty string if you want to store the file in the root directory
+ * @returns promise
+ * @example
+ * ```ts
+ * await storeFileFormData(file, 'test', '/upload')	// /upload/test.png
+ * ```
+ */
+export const storeFileFormData = async (
+	fileData: MultiPartData,
+	fileNameOrIdLength: string | number,
+	filelocation: string = '',
+): Promise<string> => {
+
+	const ext = extname(fileData.filename) // .png
+	const location = useRuntimeConfig().public.fileStorage.mount
+
+	const filename =
+		typeof fileNameOrIdLength == 'number'
+			? generateRandomId(fileNameOrIdLength)
+			: fileNameOrIdLength
+
+	const dir = pathJoin(location, filelocation)
+	const saveFilename = filename + ext
+
+	await mkdir(dir, { recursive: true })
+
+	await writeFile(pathJoin(dir, saveFilename), fileData.data, {
+		flag: 'w',
+	})
+	return saveFilename
 }


### PR DESCRIPTION
When we upload files when using api tool for interface testing, we need to further process the data into base64, so I think the front end only transmits FormData data and the back end stores it.
1. Add `useFileStorage()` return `filesList`,This is an array of file objects
2. The server adds the `storeFileFormData` method for saving `FormData` data

## Usage
Frontend
```html
<template>
  <input type="file" @input="handleFileInput" />
  <button @click="submit">submit</button>
</template>

<script setup>
const { handleFileInput, filesList } = useFileStorage()

const submit = async () => {
  const formData= new FormData()
  Array.from(filesList.value).forEach((file)=>{
    formData.append('file', file)
  })
  // formData.append('file', filesList.value[0])  // upload single file
  const response = await $fetch('/api/files', {
    method: 'POST',
    body: formData
  })
}
</script>
```
Backend
```ts
export default defineEventHandler(async (event) => {
  const files = (await readMultipartFormData(event)) || []
  const file0 = files.find(item => item.name === 'file' && item.type)
  if(!file0) return 'no file'
  await storeFileFormData(
    file, // the stringified version of the file
    8,            // you can add a name for the file or length of Unique ID that will be automatically generated!
    '/userFiles'  // the folder the file will be stored in
  )
  
  return 'success!'
})

```
